### PR TITLE
Update viz notebooks (remove geoplot, add lonboard example)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - mapclassify
   - cartopy
   - contextily
-  - geoplot
   - fsspec
   - s3fs
   - dask
@@ -30,6 +29,7 @@ dependencies:
   - ipympl
   - ipyleaflet
   - folium
+  - lonboard
   - seaborn
   - hvplot
   - geoviews

--- a/notebooks/visualization-02-geopandas.ipynb
+++ b/notebooks/visualization-02-geopandas.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "\n",
     "> *DS Python for GIS and Geoscience*  \n",
-    "> *September, 2024*\n",
+    "> *October, 2025*\n",
     ">\n",
-    "> *© 2024, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY 4.0 Creative Commons](https://creativecommons.org/licenses/by/4.0/)*\n",
+    "> *© 2025, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY 4.0 Creative Commons](https://creativecommons.org/licenses/by/4.0/)*\n",
     "\n",
     "---"
    ]
@@ -375,52 +375,6 @@
    "source": [
     "**For more on cartopy**, see the [visualization-03-cartopy.ipynb](visualization-03-cartopy.ipynb) notebook."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Using `geoplot`\n",
-    "\n",
-    "The `geoplot` packages provides some additional functionality compared to the basic `.plot()` method on GeoDataFrames:\n",
-    "\n",
-    "- High-level plotting API (with more plot types as geopandas)\n",
-    "- Native projection support through cartopy\n",
-    "\n",
-    "https://residentmario.github.io/geoplot/index.html"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import geoplot\n",
-    "import geoplot.crs as gcrs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(figsize=(10, 10), subplot_kw={\n",
-    "    'projection': gcrs.Orthographic(central_latitude=40.7128, central_longitude=-74.0059)\n",
-    "})\n",
-    "geoplot.choropleth(countries, hue='gdp_per_cap', projection=gcrs.Orthographic(), ax=ax,\n",
-    "                   cmap='magma', linewidth=0.5, edgecolor='white')\n",
-    "ax.set_global()\n",
-    "ax.spines['geo'].set_visible(True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -442,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.11"
   },
   "toc-autonumbering": false,
   "toc-showcode": false,

--- a/notebooks/visualization-02-geopandas.md
+++ b/notebooks/visualization-02-geopandas.md
@@ -15,9 +15,9 @@ kernelspec:
 
 
 > *DS Python for GIS and Geoscience*  
-> *September, 2024*
+> *October, 2025*
 >
-> *© 2024, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY 4.0 Creative Commons](https://creativecommons.org/licenses/by/4.0/)*
+> *© 2025, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY 4.0 Creative Commons](https://creativecommons.org/licenses/by/4.0/)*
 
 ---
 
@@ -197,33 +197,3 @@ ax.gridlines()
 ```
 
 **For more on cartopy**, see the [visualization-03-cartopy.ipynb](visualization-03-cartopy.ipynb) notebook.
-
-+++
-
-## Using `geoplot`
-
-The `geoplot` packages provides some additional functionality compared to the basic `.plot()` method on GeoDataFrames:
-
-- High-level plotting API (with more plot types as geopandas)
-- Native projection support through cartopy
-
-https://residentmario.github.io/geoplot/index.html
-
-```{code-cell} ipython3
-import geoplot
-import geoplot.crs as gcrs
-```
-
-```{code-cell} ipython3
-fig, ax = plt.subplots(figsize=(10, 10), subplot_kw={
-    'projection': gcrs.Orthographic(central_latitude=40.7128, central_longitude=-74.0059)
-})
-geoplot.choropleth(countries, hue='gdp_per_cap', projection=gcrs.Orthographic(), ax=ax,
-                   cmap='magma', linewidth=0.5, edgecolor='white')
-ax.set_global()
-ax.spines['geo'].set_visible(True)
-```
-
-```{code-cell} ipython3
-
-```

--- a/notebooks/visualization-03-cartopy.ipynb
+++ b/notebooks/visualization-03-cartopy.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "\n",
     "> *DS Python for GIS and Geoscience*  \n",
-    "> *September, 2025*\n",
+    "> *October, 2025*\n",
     ">\n",
     "> *© 2025, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY-SA 4.0 Creative Commons](https://creativecommons.org/licenses/by-sa/4.0/)* Adapted from material from Phil Elson and Ryan Abernathey (see below).\n",
     "\n",
@@ -761,7 +761,7 @@
    "source": [
     "## Doing More\n",
     "\n",
-    "Browse the [Cartopy Gallery](https://scitools.org.uk/cartopy/docs/latest/gallery/index.html) to learn about all the different types of data and plotting methods available!"
+    "Browse the [Cartopy Gallery](https://cartopy.readthedocs.io/stable/gallery/index.html) to learn about all the different types of data and plotting methods available!"
    ]
   }
  ],

--- a/notebooks/visualization-03-cartopy.md
+++ b/notebooks/visualization-03-cartopy.md
@@ -15,7 +15,7 @@ kernelspec:
 
 
 > *DS Python for GIS and Geoscience*  
-> *September, 2025*
+> *October, 2025*
 >
 > *© 2025, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY-SA 4.0 Creative Commons](https://creativecommons.org/licenses/by-sa/4.0/)* Adapted from material from Phil Elson and Ryan Abernathey (see below).
 
@@ -486,4 +486,4 @@ __Note__ This is what xarray is doing under the hood to pass rio/spatial arrays 
 
 ## Doing More
 
-Browse the [Cartopy Gallery](https://scitools.org.uk/cartopy/docs/latest/gallery/index.html) to learn about all the different types of data and plotting methods available!
+Browse the [Cartopy Gallery](https://cartopy.readthedocs.io/stable/gallery/index.html) to learn about all the different types of data and plotting methods available!

--- a/notebooks/visualization-04-interactive.ipynb
+++ b/notebooks/visualization-04-interactive.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "\n",
     "> *DS Python for GIS and Geoscience*  \n",
-    "> *September, 2024*\n",
+    "> *October, 2025*\n",
     ">\n",
-    "> *© 2024, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY 4.0 Creative Commons](https://creativecommons.org/licenses/by/4.0/)*\n",
+    "> *© 2025, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY 4.0 Creative Commons](https://creativecommons.org/licenses/by/4.0/)*\n",
     "\n",
     "---"
    ]
@@ -175,6 +175,40 @@
     "Making a quick interactive plot is also available as the `.explore()` method on a GeoDataFrame or GeoSeries, using the Folium package. See the [visualization-04-interactive notebook](./visualization-04-interactive.ipynb) for more information on interactive plotting packages or check the [GeoPandas documentation](https://geopandas.org/en/stable/docs/user_guide/interactive_mapping.html) for more examples.\n",
     "\n",
     "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Vector data with Lonboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lonboard is a Python library for fast, interactive geospatial vector data visualization in Jupyter. Compared to Leaflet (shown above), it is especially useful when you want to explore larger datasets.\n",
+    "\n",
+    "https://developmentseed.org/lonboard/latest/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lonboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lonboard.viz(cities)"
    ]
   },
   {
@@ -348,7 +382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/visualization-04-interactive.md
+++ b/notebooks/visualization-04-interactive.md
@@ -15,9 +15,9 @@ kernelspec:
 
 
 > *DS Python for GIS and Geoscience*  
-> *September, 2024*
+> *October, 2025*
 >
-> *© 2024, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY 4.0 Creative Commons](https://creativecommons.org/licenses/by/4.0/)*
+> *© 2025, Joris Van den Bossche and Stijn Van Hoey. Licensed under [CC BY 4.0 Creative Commons](https://creativecommons.org/licenses/by/4.0/)*
 
 ---
 
@@ -117,6 +117,22 @@ Making a quick interactive plot is also available as the `.explore()` method on 
 </div>
 
 +++
+
+## Vector data with Lonboard
+
++++
+
+Lonboard is a Python library for fast, interactive geospatial vector data visualization in Jupyter. Compared to Leaflet (shown above), it is especially useful when you want to explore larger datasets.
+
+https://developmentseed.org/lonboard/latest/
+
+```{code-cell} ipython3
+import lonboard
+```
+
+```{code-cell} ipython3
+lonboard.viz(cities)
+```
 
 ## Using Holoviews for raster data with xarray
 


### PR DESCRIPTION
Removed geoplot example, as this is no longer actively maintained. And added lonboard in the interactive section (we can see if we actually get to it)